### PR TITLE
Add gpt oss to shard repository

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -76,6 +76,7 @@ const modelMap: { [key: string]: string } = {
   // "Deepseek R1 (free)": "deepseek/deepseek-r1:free",
   "Deepseek R1 (05-28)": "deepseek/deepseek-r1-0528:free",
   "Deepseek V3 (03-24)": "deepseek/deepseek-chat-v3-0324:free",
+  "GPT OSS 20B (free)": "openrouter.ai/openai/gpt-oss-20b:free",
   "Gemini 2.0 Flash": "gemini-2.0-flash",
   "Gemini 2.5 Flash (05-20)": "gemini-2.5-flash-preview-05-20",
   "Gemini 2.5 Flash (Thinking)": "gemini-2.5-flash-preview-05-20#thinking-enabled",


### PR DESCRIPTION
Add GPT OSS 20B model to the model selector to fulfill Linear issue ORN-539.

---
Linear Issue: [ORN-539](https://linear.app/orangetasks/issue/ORN-539/add-gpt-oss-to-shard)

<a href="https://cursor.com/background-agent?bcId=bc-8d03899a-86f7-4741-a75e-96bedcb0e944">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d03899a-86f7-4741-a75e-96bedcb0e944">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

